### PR TITLE
Correct issue and PR notification rendering

### DIFF
--- a/configs/templates.cn.jsonc
+++ b/configs/templates.cn.jsonc
@@ -3528,7 +3528,7 @@
                   "tag": "div",
                   "text": {
                     "tag": "lark_md",
-                    "content": "**作者：** {{sender_link_md | default(sender.login)}}\n**Issue：** #{{issue.number}} {{issue.title}}\n**评论：** {{comment.body}}\n"
+                    "content": "**作者：** {{sender_link_md | default(sender.login)}}\n**Issue：** {{issue_link_md | default(issue.html_url | default(''))}}\n**评论：** {{comment.body}}\n"
                   }
                 },
                 {
@@ -8583,9 +8583,6 @@
                   }
                 },
                 {
-                  "tag": "hr"
-                },
-                {
                   "tag": "action",
                   "actions": [
                     {
@@ -8695,9 +8692,6 @@
                   }
                 },
                 {
-                  "tag": "hr"
-                },
-                {
                   "tag": "action",
                   "actions": [
                     {
@@ -8774,7 +8768,7 @@
               "header": {
                 "title": {
                   "tag": "plain_text",
-                  "content": "� Pull Request 已更新"
+                  "content": "🔄 Pull Request 已更新"
                 },
                 "template": "blue"
               },

--- a/configs/templates.jsonc
+++ b/configs/templates.jsonc
@@ -3528,7 +3528,7 @@
                   "tag": "div",
                   "text": {
                     "tag": "lark_md",
-                    "content": "**Author:** {{sender_link_md | default(sender.login)}}\n**Issue:** #{{issue.number}} {{issue.title}}\n**Comment:** {{comment.body}}\n"
+                    "content": "**Author:** {{sender_link_md | default(sender.login)}}\n**Issue:** {{issue_link_md | default(issue.html_url | default(''))}}\n**Comment:** {{comment.body}}\n"
                   }
                 },
                 {
@@ -8626,9 +8626,6 @@
                   }
                 },
                 {
-                  "tag": "hr"
-                },
-                {
                   "tag": "action",
                   "actions": [
                     {
@@ -8738,9 +8735,6 @@
                   }
                 },
                 {
-                  "tag": "hr"
-                },
-                {
                   "tag": "action",
                   "actions": [
                     {
@@ -8817,7 +8811,7 @@
               "header": {
                 "title": {
                   "tag": "plain_text",
-                  "content": "� Pull Request Updated"
+                  "content": "🔄 Pull Request Updated"
                 },
                 "template": "blue"
               },

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -367,6 +367,9 @@ func (h *Handler) prepareTemplateData(eventType string, payload map[string]any) 
 
 	// populate common fields shared across event types
 	prepareCommonData(data, payload)
+	if action, ok := payload["action"].(string); ok {
+		data["action"] = action
+	}
 
 	// delegate per-event handling into separate files for clarity
 	switch eventType {

--- a/internal/handler/handler_issue_comment.go
+++ b/internal/handler/handler_issue_comment.go
@@ -21,5 +21,12 @@ func prepareIssueCommentData(data map[string]any, payload map[string]any) {
 		data["issue_title"] = issue["title"]
 		data["issue_url"] = issue["html_url"]
 		data["issue"] = issue
+		if url, ok := issue["html_url"].(string); ok {
+			if title, ok := issue["title"].(string); ok && title != "" {
+				data["issue_link_md"] = fmt.Sprintf("[#%v %s](%s)", issue["number"], title, url)
+			} else {
+				data["issue_link_md"] = url
+			}
+		}
 	}
 }

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -188,6 +188,33 @@ func TestPrepareTemplateData_IssueLinks(t *testing.T) {
 	}
 }
 
+func TestPrepareTemplateData_ActionAndIssueCommentLink(t *testing.T) {
+	cfg := &config.Config{}
+	n := notifier.New(config.FeishuBotsConfig{})
+	h := New(cfg, n)
+
+	payload := map[string]any{
+		"action": "created",
+		"issue": map[string]any{
+			"number":   2,
+			"title":    "Issue title",
+			"html_url": "https://github.com/org/repo/issues/2",
+		},
+	}
+
+	for _, eventType := range []string{"team_add", "security_and_analysis", "pull_request_review", "issue_comment"} {
+		data := h.prepareTemplateData(eventType, payload)
+		if got := data["action"]; got != "created" {
+			t.Errorf("%s action = %v, want created", eventType, got)
+		}
+	}
+
+	data := h.prepareTemplateData("issue_comment", payload)
+	if got := data["issue_link_md"]; got != "[#2 Issue title](https://github.com/org/repo/issues/2)" {
+		t.Fatalf("issue_link_md = %v", got)
+	}
+}
+
 func TestPrepareTemplateData_PackageURL(t *testing.T) {
 	cfg := &config.Config{}
 	n := notifier.New(config.FeishuBotsConfig{})


### PR DESCRIPTION
## Summary
- Populate the common action template field for all webhook event types.
- Link Issue comments to their parent Issue and fix the malformed PR update emoji.
- Remove the redundant PR separator that appeared when the PR body was empty.

## Validation
- go test ./internal/handler ./internal/template ./internal/config`n- go build ./...`n
Related to #11. This intentionally does not cover image and code-block rendering, which requires a separate Feishu card/content conversion design.